### PR TITLE
feat(docker): admin panel is now exposed/runned in the docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,13 @@ COPY --from=build-stage /culivert/frontend/dist ./
 # Copy backend
 COPY ./backend .
 
+# Copy the admin panel
+WORKDIR /culivert/admin
+COPY ./admin .
+
+# By default, run backend
+WORKDIR /culivert/backend
+
 # Setup environment variables
 ENV FLASK_SECRET_KEY="DEBUG_SECRET"
 ENV FLASK_ALLOWED_EXTENSIONS='["png","jpg","jpeg","webp"]'

--- a/compose.yml
+++ b/compose.yml
@@ -12,6 +12,12 @@ services:
       FLASK_SQLALCHEMY_DATABASE_URI: "postgresql://postgres:to_change@db/postgres"
     depends_on:
       - db
+  admin:
+    build: .
+    working_dir: "/culivert/admin"
+    ports:
+      - "5001:5000"
+    restart: always
   db:
     image: postgres:16-alpine
     restart: always
@@ -25,5 +31,3 @@ services:
       - ./docker-data/init-db:/docker-entrypoint-initdb.d
       # For persistence, uncomment the following line.
       - ./docker-data/data-db:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"


### PR DESCRIPTION
* Remove unnecessary exposed port (DB port).
* Admin panel is now part of the Docker image
* The docker compose setup now runs a container for the admin panel and expose it on the port 5001.